### PR TITLE
fix: enforce CORS origin validation

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -83,7 +83,7 @@ app.use(cors({
         if (config.cors.origins.includes('*') || config.cors.origins.includes(origin)) {
             return callback(null, true);
         }
-        return callback(null, true);
+        return callback(new Error('Not allowed by CORS'));
     },
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],


### PR DESCRIPTION
## Summary
- fix CORS configuration to reject unlisted origins

## Testing
- `npm test` (fails: No tests found, exiting with code 1)


------
https://chatgpt.com/codex/tasks/task_e_6896da2f011483298a2ad346d818cddf