### PR TITLE
Add settings menu for theme management

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -297,6 +297,11 @@ body {
   margin-left: 16px;
 }
 
+.header-right {
+  display: flex;
+  gap: 8px;
+}
+
 .chat-container {
   display: flex;
   flex: 1;
@@ -577,6 +582,40 @@ body {
   opacity: 0.6;
   cursor: not-allowed;
   transform: none;
+}
+
+/* Settings Menu */
+.settings-menu {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.settings-content {
+  background: var(--background-color);
+  color: var(--text-color);
+  padding: 24px;
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-lg);
+  width: 100%;
+  max-width: 400px;
+}
+
+.settings-content h2 {
+  margin-bottom: 16px;
+  text-align: center;
+}
+
+.settings-close {
+  margin-top: 16px;
+  width: 100%;
 }
 
 /* Animations */

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -130,10 +130,10 @@ const EmailNotVerified = ({ email, onResend, onLogout }) => {
             <li>Wait a few minutes and try resending</li>
           </ul>
         </div>
+        </div>
       </div>
-    </div>
-  );
-};
+      );
+    };
 
 // Login Component
 const Login = ({ onLogin, onToggleMode }) => {
@@ -470,6 +470,28 @@ const ThemeSelector = ({ currentTheme, themes, onThemeChange, token }) => {
   );
 };
 
+// Settings Menu Component
+const SettingsMenu = ({ visible, onClose, currentTheme, themes, onThemeChange, token }) => {
+  if (!visible) return null;
+
+  return (
+    <div className="settings-menu">
+      <div className="settings-content">
+        <h2>Settings</h2>
+        <ThemeSelector
+          currentTheme={currentTheme}
+          themes={themes}
+          onThemeChange={onThemeChange}
+          token={token}
+        />
+        <button className="btn-secondary settings-close" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    </div>
+  );
+};
+
 // Chat Interface Component
 const ChatInterface = ({ user, token, onLogout }) => {
   const [sessions, setSessions] = useState([]);
@@ -479,6 +501,7 @@ const ChatInterface = ({ user, token, onLogout }) => {
   const [loading, setLoading] = useState(false);
   const [themes, setThemes] = useState([]);
   const [currentTheme, setCurrentTheme] = useState(user.themePreference || 'light');
+  const [showSettings, setShowSettings] = useState(false);
   const messagesEndRef = useRef(null);
 
   useEffect(() => {
@@ -614,6 +637,9 @@ const ChatInterface = ({ user, token, onLogout }) => {
           </span>
         </div>
         <div className="header-right">
+          <button className="btn-secondary" onClick={() => setShowSettings(true)}>
+            Settings
+          </button>
           <button className="btn-secondary" onClick={onLogout}>
             Logout
           </button>
@@ -647,12 +673,6 @@ const ChatInterface = ({ user, token, onLogout }) => {
             </div>
           </div>
 
-          <ThemeSelector
-            currentTheme={currentTheme}
-            themes={themes}
-            onThemeChange={handleThemeChange}
-            token={token}
-          />
         </div>
 
         <div className="chat-main">
@@ -712,9 +732,17 @@ const ChatInterface = ({ user, token, onLogout }) => {
           )}
         </div>
       </div>
-    </div>
-  );
-};
+      <SettingsMenu
+        visible={showSettings}
+        onClose={() => setShowSettings(false)}
+        currentTheme={currentTheme}
+        themes={themes}
+        onThemeChange={handleThemeChange}
+        token={token}
+      />
+      </div>
+    );
+  };
 
 // Main App Component
 const App = () => {


### PR DESCRIPTION
## Summary
- add overlay-based SettingsMenu with theme selector
- move theme controls out of sidebar and add Settings button in header
- style settings overlay and header buttons for cleaner UI

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6896db9d2d7883298b5843ab1475f847