### PR TITLE
feat: add websocket support

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -12,6 +12,8 @@ const crypto = require('crypto');
 const { v4: uuidv4 } = require('uuid');
 const fs = require('fs');
 const path = require('path');
+const http = require('http');
+const { Server } = require('socket.io');
 
 // Import Email Service
 const EmailService = require('./services/emailService');
@@ -70,6 +72,27 @@ pool.query('SELECT NOW()', (err, res) => {
 const emailService = new EmailService(config, logger);
 
 const app = express();
+
+// HTTP server and WebSocket setup
+const server = http.createServer(app);
+const io = new Server(server, {
+    cors: {
+        origin: config.cors.origins.includes('*') ? '*' : config.cors.origins,
+        methods: ['GET', 'POST']
+    }
+});
+
+io.on('connection', (socket) => {
+    logger.info('WebSocket client connected');
+
+    socket.on('joinSession', (sessionId) => {
+        socket.join(`session_${sessionId}`);
+    });
+
+    socket.on('disconnect', () => {
+        logger.info('WebSocket client disconnected');
+    });
+});
 
 // Security middleware
 app.use(helmet({
@@ -750,6 +773,7 @@ app.post('/api/chat/message', authenticateToken, async (req, res) => {
         );
 
         const userMessage = messageResult.rows[0];
+        io.to(`session_${sessionId}`).emit('newMessage', userMessage);
         let webhookResponse = null;
         let responseTime = null;
 
@@ -787,11 +811,13 @@ app.post('/api/chat/message', authenticateToken, async (req, res) => {
                     ? webhookResponse 
                     : (webhookResponse.text || webhookResponse.response || JSON.stringify(webhookResponse, null, 2));
 
-                await pool.query(
+                const botMessageResult = await pool.query(
                     `INSERT INTO messages (session_id, user_id, message_text, message_type, webhook_response, response_time_ms)
-                     VALUES ($1, $2, $3, 'bot', $4, $5)`,
+                     VALUES ($1, $2, $3, 'bot', $4, $5) RETURNING *`,
                     [sessionId, userId, botMessageText, JSON.stringify(webhookResponse), responseTime]
                 );
+                const botMessage = botMessageResult.rows[0];
+                io.to(`session_${sessionId}`).emit('newMessage', botMessage);
 
             } catch (error) {
                 responseTime = Date.now() - startTime;
@@ -859,7 +885,7 @@ app.use((req, res) => {
 
 // Start server
 const PORT = config.server.port;
-app.listen(PORT, config.server.host, async () => {
+server.listen(PORT, config.server.host, async () => {
     logger.info(`Server running on ${config.server.host}:${PORT}`);
     logger.info(`Public URL: ${config.server.publicUrl}`);
     

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1"
+    "react-scripts": "5.0.1",
+    "socket.io-client": "^4.8.1"
   },
   "scripts": {
     "start": "DANGEROUSLY_DISABLE_HOST_CHECK=true HOST=0.0.0.0 react-scripts start",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,7 @@
 // WebChat - Simple Interface with Email Verification Messages - App.js
 import React, { useState, useEffect, useRef } from 'react';
 import './App.css';
+import { io } from 'socket.io-client';
 
 // API Configuration
 const API_BASE_URL = 'http://winwin2home.3bbddns.com:53632';
@@ -480,15 +481,24 @@ const ChatInterface = ({ user, token, onLogout }) => {
   const [themes, setThemes] = useState([]);
   const [currentTheme, setCurrentTheme] = useState(user.themePreference || 'light');
   const messagesEndRef = useRef(null);
+  const socketRef = useRef(null);
 
   useEffect(() => {
     loadSessions();
     loadThemes();
+    socketRef.current = io(API_BASE_URL);
+    socketRef.current.on('newMessage', (message) => {
+      setMessages(prev => [...prev, message]);
+    });
+    return () => {
+      socketRef.current.disconnect();
+    };
   }, []);
 
   useEffect(() => {
     if (currentSession) {
       loadMessages(currentSession.id);
+      socketRef.current.emit('joinSession', currentSession.id);
     }
   }, [currentSession]);
 
@@ -552,34 +562,10 @@ const ChatInterface = ({ user, token, onLogout }) => {
     setNewMessage('');
 
     try {
-      const response = await api.post('/api/chat/message', {
+      await api.post('/api/chat/message', {
         sessionId: currentSession.id,
         message: messageText
       }, token);
-
-      // Add user message
-      const userMessage = {
-        ...response.userMessage,
-        created_at: new Date().toISOString()
-      };
-      
-      setMessages(prev => [...prev, userMessage]);
-
-      // Add bot response if available
-      if (response.webhookResponse) {
-        const botMessage = {
-          id: Date.now(),
-          message_text: typeof response.webhookResponse === 'string' 
-            ? response.webhookResponse 
-            : (response.webhookResponse.text || response.webhookResponse.response || JSON.stringify(response.webhookResponse, null, 2)),
-          message_type: 'bot',
-          created_at: new Date().toISOString(),
-          response_time_ms: response.responseTime
-        };
-        
-        setMessages(prev => [...prev, botMessage]);
-      }
-
     } catch (err) {
       console.error('Failed to send message:', err);
       alert('Failed to send message');


### PR DESCRIPTION
## Summary
- add socket.io server and broadcast messages to session rooms
- hook frontend to WebSocket and update chat state on push
- drop manual message refresh logic and clean sendMessage handler

## Testing
- `cd frontend && npm test --silent` *(no tests found)*
- `cd backend && npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6896dfa26a2c8329a4278fe52232fccd