### PR TITLE
Load API base URL from environment variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+REACT_APP_API_BASE_URL=http://winwin2home.3bbddns.com:53632

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ yarn-error.log*
 /backend/dist
 
 # Environment variables
-.env
+# .env file tracked for development configuration
 .env.local
 .env.development.local
 .env.test.local

--- a/README.md
+++ b/README.md
@@ -5,5 +5,17 @@ A web-based chat application with webhook integration, user authentication, and 
 ## Quick Start
 
 1. Run setup:
+
    ```bash
    ./setup.sh
+   ```
+
+2. Configure environment:
+
+   Create a `.env` file in the project root and set the API base URL used by the frontend:
+
+   ```bash
+   REACT_APP_API_BASE_URL=http://winwin2home.3bbddns.com:53632
+   ```
+
+   Replace the URL with your backend's address if different.

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import './App.css';
 
 // API Configuration
-const API_BASE_URL = 'http://winwin2home.3bbddns.com:53632';
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
 
 // API Helper Functions
 const api = {

--- a/restart.sh
+++ b/restart.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Load environment variables
+set -a
+[ -f .env ] && source .env
+set +a
+
 echo "🔄 Restarting WebChat Services"
 
 # Stop all node processes

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Load environment variables
+set -a
+[ -f .env ] && source .env
+set +a
+
 echo "🚀 Starting WebChat services..."
 
 # Start database

--- a/start_production.sh
+++ b/start_production.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Load environment variables
+set -a
+[ -f .env ] && source .env
+set +a
+
 echo "🚀 Starting WebChat in Production Mode"
 
 # Stop existing services


### PR DESCRIPTION
## Summary
- replace hard-coded API base URL with `process.env.REACT_APP_API_BASE_URL`
- add `.env` config and document `REACT_APP_API_BASE_URL`
- source `.env` in start scripts so builds see environment variables

## Testing
- `bash -n start.sh`
- `bash -n start_production.sh`
- `bash -n restart.sh`
- `npm test -- --watchAll=false --passWithNoTests` (frontend)
- `npm test -- --passWithNoTests` (backend)

------
https://chatgpt.com/codex/tasks/task_e_6896dfa3fed08329bd1b2945498eea16