### PR TITLE
Add unit tests and CI for webchat

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install backend dependencies
+        run: npm ci --prefix backend
+      - name: Run backend tests
+        run: npm test --prefix backend
+      - name: Install frontend dependencies
+        run: npm ci --prefix frontend
+      - name: Run frontend tests
+        run: CI=true npm test --prefix frontend

--- a/backend/__tests__/auth.test.js
+++ b/backend/__tests__/auth.test.js
@@ -1,0 +1,23 @@
+const request = require('supertest');
+
+// Mock pg to avoid real database connections
+jest.mock('pg', () => {
+  const mPool = {
+    query: jest.fn((text, params, cb) => {
+      if (typeof params === 'function') cb = params;
+      if (cb) cb(null, { rows: [] });
+      return Promise.resolve({ rows: [] });
+    })
+  };
+  return { Pool: jest.fn(() => mPool) };
+});
+
+const app = require('../server');
+
+describe('Authentication API', () => {
+  test('requires email and password on login', async () => {
+    const res = await request(app).post('/api/auth/login').send({});
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toHaveProperty('error', 'Email and password are required');
+  });
+});

--- a/backend/__tests__/chat.test.js
+++ b/backend/__tests__/chat.test.js
@@ -1,0 +1,23 @@
+const request = require('supertest');
+
+// Mock pg to avoid real database connections
+jest.mock('pg', () => {
+  const mPool = {
+    query: jest.fn((text, params, cb) => {
+      if (typeof params === 'function') cb = params;
+      if (cb) cb(null, { rows: [] });
+      return Promise.resolve({ rows: [] });
+    })
+  };
+  return { Pool: jest.fn(() => mPool) };
+});
+
+const app = require('../server');
+
+describe('Chat session API', () => {
+  test('denies access without authentication', async () => {
+    const res = await request(app).get('/api/chat/sessions');
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toHaveProperty('error', 'Access token required');
+  });
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "jest",
+    "test": "NODE_ENV=test jest",
     "migrate": "node scripts/migrate.js",
     "seed": "node scripts/seed.js"
   },
@@ -41,6 +41,9 @@
     "jest": "^29.7.0",
     "nodemon": "^3.0.2",
     "supertest": "^6.3.3"
+  },
+  "jest": {
+    "testEnvironment": "node"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/backend/server.js
+++ b/backend/server.js
@@ -857,21 +857,23 @@ app.use((req, res) => {
     res.status(404).json({ error: 'Endpoint not found' });
 });
 
-// Start server
+// Start server when not running tests
 const PORT = config.server.port;
-app.listen(PORT, config.server.host, async () => {
-    logger.info(`Server running on ${config.server.host}:${PORT}`);
-    logger.info(`Public URL: ${config.server.publicUrl}`);
-    
-    if (config.email && config.email.enabled) {
-        const emailWorking = await emailService.testConnection();
-        if (emailWorking) {
-            logger.info('✅ Email service is ready');
-        } else {
-            logger.warn('⚠️ Email service is not configured properly');
+if (process.env.NODE_ENV !== 'test') {
+    app.listen(PORT, config.server.host, async () => {
+        logger.info(`Server running on ${config.server.host}:${PORT}`);
+        logger.info(`Public URL: ${config.server.publicUrl}`);
+
+        if (config.email && config.email.enabled) {
+            const emailWorking = await emailService.testConnection();
+            if (emailWorking) {
+                logger.info('✅ Email service is ready');
+            } else {
+                logger.warn('⚠️ Email service is not configured properly');
+            }
         }
-    }
-});
+    });
+}
 
 process.on('SIGTERM', () => {
     logger.info('SIGTERM received, shutting down gracefully');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "DANGEROUSLY_DISABLE_HOST_CHECK=true HOST=0.0.0.0 react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+test('renders sign in form by default', async () => {
+  const container = document.createElement('div');
+  await act(async () => {
+    createRoot(container).render(<App />);
+  });
+  expect(container.innerHTML).toMatch(/Sign In/);
+});


### PR DESCRIPTION
## Summary
- configure backend and frontend for Jest testing
- add API and React component tests
- run tests in GitHub Actions workflow

## Testing
- `npm test --prefix backend`
- `CI=true npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6896dfa831588329bdd5a07f7d4827c6