### PR TITLE
feat: configure public URLs via environment variables

### DIFF
--- a/backend/config.json
+++ b/backend/config.json
@@ -2,10 +2,10 @@
   "server": {
     "port": 3001,
     "host": "0.0.0.0",
-    "publicUrl": "XXXXXX"
+    "publicUrl": "http://localhost:3001"
   },
   "frontend": {
-    "publicUrl": "XXXXXX"
+    "publicUrl": "http://localhost:3000"
   },
   "database": {
     "host": "localhost",

--- a/backend/server.js
+++ b/backend/server.js
@@ -15,11 +15,15 @@ const path = require('path');
 const http = require('http');
 const { Server } = require('socket.io');
 
+require('dotenv').config();
+
 // Import Email Service
 const EmailService = require('./services/emailService');
 
 // Load configuration
 const config = require('./config.json');
+config.server.publicUrl = process.env.SERVER_PUBLIC_URL || config.server.publicUrl;
+config.frontend.publicUrl = process.env.FRONTEND_PUBLIC_URL || config.frontend.publicUrl;
 const authRouter = require('./auth');
 
 // Create logs directory


### PR DESCRIPTION
## Summary
- set default backend and frontend public URLs
- allow overriding public URLs via environment variables using dotenv

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6896f181a7d48329b04705e10666be50