### PR TITLE
Add ability to delete chat sessions

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -751,6 +751,29 @@ app.get('/api/chat/sessions', authenticateToken, async (req, res) => {
     }
 });
 
+app.delete('/api/chat/sessions/:sessionId', authenticateToken, async (req, res) => {
+    try {
+        const { sessionId } = req.params;
+        const userId = req.user.id;
+
+        const result = await pool.query(
+            `UPDATE chat_sessions SET is_active = false, updated_at = CURRENT_TIMESTAMP
+             WHERE id = $1 AND user_id = $2 AND is_active = true RETURNING *`,
+            [sessionId, userId]
+        );
+
+        if (result.rows.length === 0) {
+            return res.status(404).json({ error: 'Session not found' });
+        }
+
+        await logUserActivity(userId, 'chat_session_deleted', { sessionId }, req);
+        res.json({ success: true });
+    } catch (error) {
+        logger.error('Delete session error:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
 // Send message
 app.post('/api/chat/message', authenticateToken, async (req, res) => {
     try {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -69,6 +69,25 @@ const api = {
     }
     
     return response.json();
+  },
+
+  delete: async (endpoint, token = null) => {
+    const headers = {};
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+
+    const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+      method: 'DELETE',
+      headers,
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.error || 'Request failed');
+    }
+
+    return response.json();
   }
 };
 
@@ -576,6 +595,21 @@ const ChatInterface = ({ user, token, onLogout }) => {
     }
   };
 
+  const deleteSession = async (sessionId) => {
+    if (!window.confirm('Are you sure you want to delete this session?')) return;
+    try {
+      await api.delete(`/api/chat/sessions/${sessionId}`, token);
+      setSessions((prev) => prev.filter((s) => s.id !== sessionId));
+      if (currentSession?.id === sessionId) {
+        setCurrentSession(null);
+        setMessages([]);
+      }
+    } catch (err) {
+      console.error('Failed to delete session:', err);
+      alert('Failed to delete session');
+    }
+  };
+
   const sendMessage = async (e) => {
     e.preventDefault();
     if (!newMessage.trim() || !currentSession) return;
@@ -648,12 +682,23 @@ const ChatInterface = ({ user, token, onLogout }) => {
                   className={`session-item ${currentSession?.id === session.id ? 'active' : ''}`}
                   onClick={() => setCurrentSession(session)}
                 >
-                  <div className="session-name">
-                    {session.session_name || `Chat ${session.id}`}
+                  <div className="session-info">
+                    <div className="session-name">
+                      {session.session_name || `Chat ${session.id}`}
+                    </div>
+                    <div className="session-meta">
+                      {session.message_count} messages
+                    </div>
                   </div>
-                  <div className="session-meta">
-                    {session.message_count} messages
-                  </div>
+                  <button
+                    className="btn-small delete-button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      deleteSession(session.id);
+                    }}
+                  >
+                    Delete
+                  </button>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- implement DELETE /api/chat/sessions/:sessionId to deactivate sessions and log activity
- add frontend controls to delete sessions, including API helper and session list button

## Testing
- `cd backend && npm test -- --passWithNoTests`
- `cd frontend && npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6896f182575c8329bea75f32797b44fb