### PR TITLE
Add password reset flow

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -349,6 +349,88 @@ app.post('/api/auth/login', async (req, res) => {
     }
 });
 
+// Request password reset
+app.post('/api/auth/request-password-reset', async (req, res) => {
+    try {
+        const { email } = req.body;
+
+        if (!email) {
+            return res.status(400).json({ error: 'Email is required' });
+        }
+
+        const userResult = await pool.query('SELECT id, email, first_name FROM users WHERE email = $1', [email]);
+        if (userResult.rows.length === 0) {
+            return res.status(404).json({ error: 'User not found' });
+        }
+
+        const user = userResult.rows[0];
+
+        await pool.query('DELETE FROM password_reset_tokens WHERE user_id = $1', [user.id]);
+
+        const token = generateVerificationToken();
+        const expiresAt = new Date(Date.now() + (config.email.templates.passwordReset.expiryHours || 1) * 60 * 60 * 1000);
+
+        await pool.query(
+            `INSERT INTO password_reset_tokens (user_id, token, expires_at)
+             VALUES ($1, $2, $3)`,
+            [user.id, token, expiresAt]
+        );
+
+        if (emailService) {
+            const emailSent = await emailService.sendPasswordResetEmail(user, token);
+            if (!emailSent) {
+                throw new Error('Failed to send password reset email');
+            }
+        }
+
+        res.json({ message: 'Password reset email sent' });
+    } catch (error) {
+        logger.error('Password reset request error:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
+// Reset password
+app.post('/api/auth/reset-password', async (req, res) => {
+    try {
+        const { token, password } = req.body;
+
+        if (!token || !password) {
+            return res.status(400).json({ error: 'Token and password are required' });
+        }
+
+        if (password.length < 8) {
+            return res.status(400).json({ error: 'Password must be at least 8 characters long' });
+        }
+
+        const tokenResult = await pool.query(
+            `SELECT * FROM password_reset_tokens
+             WHERE token = $1 AND expires_at > NOW() AND used_at IS NULL`,
+            [token]
+        );
+
+        if (tokenResult.rows.length === 0) {
+            return res.status(400).json({ error: 'Invalid or expired token' });
+        }
+
+        const resetToken = tokenResult.rows[0];
+
+        const passwordHash = await bcrypt.hash(password, config.auth.bcryptSaltRounds);
+
+        await pool.query('UPDATE users SET password_hash = $1 WHERE id = $2', [passwordHash, resetToken.user_id]);
+
+        await pool.query('UPDATE password_reset_tokens SET used_at = NOW() WHERE id = $1', [resetToken.id]);
+
+        await logAudit(resetToken.user_id, 'PASSWORD_RESET', 'users', resetToken.user_id, null, null, req);
+        await logUserActivity(resetToken.user_id, 'password_reset', null, req);
+
+        res.json({ message: 'Password has been reset successfully' });
+    } catch (error) {
+        logger.error('Password reset error:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
 // Get user profile
 app.get('/api/user/profile', authenticateToken, (req, res) => {
     res.json({

--- a/backend/services/emailService.js
+++ b/backend/services/emailService.js
@@ -127,6 +127,47 @@ WebChat Team
         }
     }
 
+    async sendPasswordResetEmail(user, token) {
+        if (!this.transporter) {
+            this.logger.warn('Email service not configured, skipping password reset email');
+            return false;
+        }
+
+        try {
+            const resetUrl = `${this.config.frontend.publicUrl}/reset-password?token=${token}`;
+
+            const mailOptions = {
+                from: {
+                    name: this.config.email.fromName || 'WebChat',
+                    address: this.config.email.fromAddress || 'noreply@webchat.local'
+                },
+                to: user.email,
+                subject: this.config.email.templates.passwordReset.subject || 'Password Reset',
+                html: this.getPasswordResetEmailTemplate(user, resetUrl),
+                text: `
+Hello ${user.first_name},
+
+Please reset your password by clicking the link below:
+${resetUrl}
+
+This link will expire in ${this.config.email.templates.passwordReset.expiryHours} hours.
+
+If you didn't request a password reset, please ignore this email.
+
+Best regards,
+WebChat Team
+                `.trim()
+            };
+
+            const result = await this.transporter.sendMail(mailOptions);
+            this.logger.info(`Password reset email sent to ${user.email}`, { messageId: result.messageId });
+            return true;
+        } catch (error) {
+            this.logger.error('Failed to send password reset email:', error);
+            return false;
+        }
+    }
+
     getVerificationEmailTemplate(user, verificationUrl) {
         return `
         <!DOCTYPE html>
@@ -164,6 +205,49 @@ WebChat Team
                     
                     <p><strong>Note:</strong> This link will expire in 24 hours.</p>
                     <p>If you didn't create an account with WebChat, please ignore this email.</p>
+                </div>
+                <div class="footer">
+                    <p>© 2025 WebChat. All rights reserved.</p>
+                </div>
+            </div>
+        </body>
+        </html>
+        `;
+    }
+
+    getPasswordResetEmailTemplate(user, resetUrl) {
+        return `
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta charset="utf-8">
+            <title>Password Reset</title>
+            <style>
+                body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; margin: 0; padding: 20px; background-color: #f4f4f4; }
+                .container { max-width: 600px; margin: 0 auto; background: white; border-radius: 10px; overflow: hidden; box-shadow: 0 0 20px rgba(0,0,0,0.1); }
+                .header { background: linear-gradient(135deg, #6366f1, #3b82f6); color: white; padding: 30px; text-align: center; }
+                .content { padding: 30px; }
+                .button { display: inline-block; background: #3b82f6; color: white; padding: 15px 30px; text-decoration: none; border-radius: 5px; margin: 20px 0; font-weight: bold; }
+                .footer { background: #f8f9fa; padding: 20px; text-align: center; font-size: 14px; color: #666; }
+            </style>
+        </head>
+        <body>
+            <div class="container">
+                <div class="header">
+                    <h1>🔒 Reset Your Password</h1>
+                </div>
+                <div class="content">
+                    <h2>Hello ${user.first_name}!</h2>
+                    <p>We received a request to reset your password. Click the button below to choose a new one.</p>
+                    <div style="text-align: center;">
+                        <a href="${resetUrl}" class="button">Reset Password</a>
+                    </div>
+                    <p>Or copy and paste this link into your browser:</p>
+                    <p style="word-break: break-all; background: #f8f9fa; padding: 10px; border-radius: 5px; font-family: monospace;">
+                        ${resetUrl}
+                    </p>
+                    <p><strong>Note:</strong> This link will expire in ${this.config.email.templates.passwordReset.expiryHours} hours.</p>
+                    <p>If you didn't request a password reset, you can safely ignore this email.</p>
                 </div>
                 <div class="footer">
                     <p>© 2025 WebChat. All rights reserved.</p>

--- a/database_schema.sql
+++ b/database_schema.sql
@@ -120,6 +120,20 @@ CREATE INDEX idx_audit_logs_created_at ON audit_logs(created_at);
 CREATE INDEX idx_user_activity_logs_user_id ON user_activity_logs(user_id);
 CREATE INDEX idx_user_activity_logs_created_at ON user_activity_logs(created_at);
 
+-- Password reset tokens table
+CREATE TABLE password_reset_tokens (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    token VARCHAR(255) UNIQUE NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    used_at TIMESTAMP NULL
+);
+
+-- Indexes for password reset tokens
+CREATE INDEX idx_password_reset_tokens_token ON password_reset_tokens(token);
+CREATE INDEX idx_password_reset_tokens_user_id ON password_reset_tokens(user_id);
+
 -- Function to update updated_at timestamp
 CREATE OR REPLACE FUNCTION update_updated_at_column()
 RETURNS TRIGGER AS $$

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -137,7 +137,7 @@ const EmailNotVerified = ({ email, onResend, onLogout }) => {
     };
 
 // Login Component
-const Login = ({ onLogin, onToggleMode }) => {
+const Login = ({ onLogin, onToggleMode, onForgotPassword }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
@@ -246,6 +246,11 @@ const Login = ({ onLogin, onToggleMode }) => {
             {loading ? 'Signing In...' : 'Sign In'}
           </button>
         </form>
+        <p>
+          <button className="link-button" type="button" onClick={onForgotPassword}>
+            Forgot password?
+          </button>
+        </p>
         <p>
           Don't have an account?{' '}
           <button className="link-button" onClick={onToggleMode}>
@@ -419,6 +424,133 @@ const Register = ({ onRegister, onToggleMode }) => {
           Already have an account?{' '}
           <button className="link-button" onClick={onToggleMode}>
             Sign in
+          </button>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+// Forgot Password Component
+const ForgotPassword = ({ onBack }) => {
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setMessage('');
+    setError('');
+    try {
+      await api.post('/api/auth/request-password-reset', { email });
+      setMessage('Password reset email sent. Please check your inbox.');
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-container">
+      <div className="auth-card">
+        <h2>Forgot Password</h2>
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label htmlFor="resetEmail">Email</label>
+            <input
+              type="email"
+              id="resetEmail"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              disabled={loading}
+            />
+          </div>
+          {message && <div className="message success">{message}</div>}
+          {error && <div className="message error">{error}</div>}
+          <button type="submit" className="btn-primary" disabled={loading}>
+            {loading ? 'Sending...' : 'Send Reset Link'}
+          </button>
+        </form>
+        <p>
+          <button className="link-button" onClick={onBack}>
+            Back to login
+          </button>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+// Reset Password Component
+const ResetPassword = ({ token, onBack }) => {
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setMessage('');
+    setError('');
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match');
+      setLoading(false);
+      return;
+    }
+
+    try {
+      await api.post('/api/auth/reset-password', { token, password });
+      setMessage('Password has been reset. You can now log in.');
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-container">
+      <div className="auth-card">
+        <h2>Reset Password</h2>
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label htmlFor="newPassword">New Password</label>
+            <input
+              type="password"
+              id="newPassword"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              disabled={loading}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="confirmNewPassword">Confirm Password</label>
+            <input
+              type="password"
+              id="confirmNewPassword"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              required
+              disabled={loading}
+            />
+          </div>
+          {message && <div className="message success">{message}</div>}
+          {error && <div className="message error">{error}</div>}
+          <button type="submit" className="btn-primary" disabled={loading}>
+            {loading ? 'Resetting...' : 'Reset Password'}
+          </button>
+        </form>
+        <p>
+          <button className="link-button" onClick={onBack}>
+            Back to login
           </button>
         </p>
       </div>
@@ -734,18 +866,27 @@ const ChatInterface = ({ user, token, onLogout }) => {
 const App = () => {
   const [user, setUser] = useState(null);
   const [token, setToken] = useState(null);
-  const [isLogin, setIsLogin] = useState(true);
+  const [authMode, setAuthMode] = useState('login');
+  const [resetToken, setResetToken] = useState(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const savedToken = localStorage.getItem('token');
     const savedUser = localStorage.getItem('user');
-    
+
     if (savedToken && savedUser) {
       setToken(savedToken);
       setUser(JSON.parse(savedUser));
     }
-    
+
+    const params = new URLSearchParams(window.location.search);
+    const reset = params.get('token');
+    if (reset) {
+      setAuthMode('reset');
+      setResetToken(reset);
+      window.history.replaceState({}, document.title, window.location.pathname);
+    }
+
     setLoading(false);
   }, []);
 
@@ -755,7 +896,7 @@ const App = () => {
   };
 
   const handleRegister = () => {
-    setIsLogin(true);
+    setAuthMode('login');
     alert('Registration successful! Please log in.');
   };
 
@@ -781,10 +922,17 @@ const App = () => {
 
   return (
     <div className="app">
-      {isLogin ? (
-        <Login onLogin={handleLogin} onToggleMode={() => setIsLogin(false)} />
-      ) : (
-        <Register onRegister={handleRegister} onToggleMode={() => setIsLogin(true)} />
+      {authMode === 'login' && (
+        <Login onLogin={handleLogin} onToggleMode={() => setAuthMode('register')} onForgotPassword={() => setAuthMode('forgot')} />
+      )}
+      {authMode === 'register' && (
+        <Register onRegister={handleRegister} onToggleMode={() => setAuthMode('login')} />
+      )}
+      {authMode === 'forgot' && (
+        <ForgotPassword onBack={() => setAuthMode('login')} />
+      )}
+      {authMode === 'reset' && (
+        <ResetPassword token={resetToken} onBack={() => setAuthMode('login')} />
       )}
     </div>
   );

--- a/password_reset_update.sql
+++ b/password_reset_update.sql
@@ -1,0 +1,13 @@
+-- Create password reset tokens table
+CREATE TABLE IF NOT EXISTS password_reset_tokens (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    token VARCHAR(255) UNIQUE NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    used_at TIMESTAMP NULL
+);
+
+-- Add indexes
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_token ON password_reset_tokens(token);
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user_id ON password_reset_tokens(user_id);


### PR DESCRIPTION
## Summary
- add password_reset_tokens table and migration
- support password reset emails and API endpoints
- implement frontend password reset request and form

## Testing
- `npm test -- --passWithNoTests` (backend)
- `CI=true npm test -- --passWithNoTests` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6896f1840be883298be3e1b1f1540bcd