### PR TITLE
feat: allow renaming chat sessions

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -751,6 +751,36 @@ app.get('/api/chat/sessions', authenticateToken, async (req, res) => {
     }
 });
 
+app.put('/api/chat/sessions/:sessionId', authenticateToken, async (req, res) => {
+    try {
+        const { sessionId } = req.params;
+        const { sessionName } = req.body;
+        const userId = req.user.id;
+
+        if (!sessionName || sessionName.trim() === '') {
+            return res.status(400).json({ error: 'Session name is required' });
+        }
+
+        const result = await pool.query(
+            `UPDATE chat_sessions SET session_name = $1, updated_at = CURRENT_TIMESTAMP
+             WHERE id = $2 AND user_id = $3 AND is_active = true RETURNING *`,
+            [sessionName, sessionId, userId]
+        );
+
+        if (result.rows.length === 0) {
+            return res.status(404).json({ error: 'Session not found' });
+        }
+
+        const session = result.rows[0];
+        await logUserActivity(userId, 'chat_session_renamed', { sessionId: session.id, sessionName: session.session_name }, req);
+
+        res.json(session);
+    } catch (error) {
+        logger.error('Rename session error:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
 // Send message
 app.post('/api/chat/message', authenticateToken, async (req, res) => {
     try {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -348,6 +348,9 @@ body {
   transition: var(--transition);
   margin-bottom: 8px;
   border: 1px solid transparent;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .session-item:hover {
@@ -358,6 +361,14 @@ body {
   background-color: var(--primary-color);
   color: white;
   border-color: var(--primary-color);
+}
+
+.session-details {
+  flex: 1;
+}
+
+.rename-button {
+  margin-left: 8px;
 }
 
 .session-name {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -576,6 +576,22 @@ const ChatInterface = ({ user, token, onLogout }) => {
     }
   };
 
+  const renameSession = async (session) => {
+    const newName = prompt('Enter new session name:', session.session_name || '');
+    if (!newName || newName.trim() === '' || newName === session.session_name) return;
+    try {
+      const updated = await api.put(`/api/chat/sessions/${session.id}`, { sessionName: newName }, token);
+      const sessionWithMeta = { ...session, ...updated };
+      setSessions(sessions.map(s => s.id === session.id ? sessionWithMeta : s));
+      if (currentSession && currentSession.id === session.id) {
+        setCurrentSession(sessionWithMeta);
+      }
+    } catch (err) {
+      console.error('Failed to rename session:', err);
+      alert('Failed to rename session');
+    }
+  };
+
   const sendMessage = async (e) => {
     e.preventDefault();
     if (!newMessage.trim() || !currentSession) return;
@@ -648,12 +664,23 @@ const ChatInterface = ({ user, token, onLogout }) => {
                   className={`session-item ${currentSession?.id === session.id ? 'active' : ''}`}
                   onClick={() => setCurrentSession(session)}
                 >
-                  <div className="session-name">
-                    {session.session_name || `Chat ${session.id}`}
+                  <div className="session-details">
+                    <div className="session-name">
+                      {session.session_name || `Chat ${session.id}`}
+                    </div>
+                    <div className="session-meta">
+                      {session.message_count} messages
+                    </div>
                   </div>
-                  <div className="session-meta">
-                    {session.message_count} messages
-                  </div>
+                  <button
+                    className="link-button btn-small rename-button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      renameSession(session);
+                    }}
+                  >
+                    Rename
+                  </button>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- allow renaming chat sessions via new backend PUT endpoint
- add Rename action in UI and update styles

## Testing
- `npm test` (backend) *(fails: No tests found, exiting with code 1)*
- `CI=true npm test` (frontend) *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6896f18528388329a55d77d66b12af39