### PR TITLE
refactor: reposition settings menu

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -779,6 +779,7 @@ const ChatInterface = ({ user, token, onLogout }) => {
   };
 
   return (
+    <>
     <div className={`chat-app theme-${currentTheme}`}>
       <div className="chat-header">
         <div className="header-left">
@@ -895,16 +896,17 @@ const ChatInterface = ({ user, token, onLogout }) => {
           )}
         </div>
       </div>
-      <SettingsMenu
-        visible={showSettings}
-        onClose={() => setShowSettings(false)}
-        currentTheme={currentTheme}
-        themes={themes}
-        onThemeChange={handleThemeChange}
-        token={token}
-      />
-      </div>
-    );
+    </div>
+    <SettingsMenu
+      visible={showSettings}
+      onClose={() => setShowSettings(false)}
+      currentTheme={currentTheme}
+      themes={themes}
+      onThemeChange={handleThemeChange}
+      token={token}
+    />
+    </>
+  );
   };
 
 // Main App Component


### PR DESCRIPTION
## Summary
- wrap ChatInterface JSX in a fragment and move the settings menu outside the main chat container

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6896f8097358832997856ab719057f31