### PR TITLE
feat: support multiline messages and image upload

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -861,11 +861,11 @@ app.delete('/api/chat/sessions/:sessionId', authenticateToken, async (req, res) 
 // Send message
 app.post('/api/chat/message', authenticateToken, async (req, res) => {
     try {
-        const { sessionId, message } = req.body;
+        const { sessionId, message, image } = req.body;
         const userId = req.user.id;
 
-        if (!sessionId || !message) {
-            return res.status(400).json({ error: 'Session ID and message are required' });
+        if (!sessionId || (!message && !image)) {
+            return res.status(400).json({ error: 'Session ID and message or image are required' });
         }
 
         const sessionResult = await pool.query(
@@ -877,10 +877,12 @@ app.post('/api/chat/message', authenticateToken, async (req, res) => {
             return res.status(404).json({ error: 'Session not found' });
         }
 
+        const content = message || image;
+        const type = image ? 'image' : 'user';
         const messageResult = await pool.query(
             `INSERT INTO messages (session_id, user_id, message_text, message_type)
-             VALUES ($1, $2, $3, 'user') RETURNING *`,
-            [sessionId, userId, message]
+             VALUES ($1, $2, $3, $4) RETURNING *`,
+            [sessionId, userId, content, type]
         );
 
         const userMessage = messageResult.rows[0];
@@ -888,7 +890,7 @@ app.post('/api/chat/message', authenticateToken, async (req, res) => {
         let webhookResponse = null;
         let responseTime = null;
 
-        if (config.webhook.enabled && config.webhook.url) {
+        if (config.webhook.enabled && config.webhook.url && message) {
             const startTime = Date.now();
             try {
                 const payload = {
@@ -938,7 +940,7 @@ app.post('/api/chat/message', authenticateToken, async (req, res) => {
         }
 
         await pool.query('UPDATE chat_sessions SET updated_at = CURRENT_TIMESTAMP WHERE id = $1', [sessionId]);
-        await logUserActivity(userId, 'message_sent', { sessionId, messageLength: message.length }, req);
+        await logUserActivity(userId, 'message_sent', { sessionId, messageLength: content.length }, req);
 
         res.json({
             userMessage,

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -584,6 +584,20 @@ body {
   transform: none;
 }
 
+.image-preview {
+  margin-bottom: 8px;
+}
+
+.image-preview img {
+  max-height: 100px;
+  border-radius: var(--border-radius);
+}
+
+.message-image {
+  max-width: 300px;
+  border-radius: var(--border-radius);
+}
+
 /* Settings Menu */
 .settings-menu {
   position: fixed;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -650,12 +650,14 @@ const ChatInterface = ({ user, token, onLogout }) => {
   const [currentSession, setCurrentSession] = useState(null);
   const [messages, setMessages] = useState([]);
   const [newMessage, setNewMessage] = useState('');
+  const [selectedImage, setSelectedImage] = useState(null);
   const [loading, setLoading] = useState(false);
   const [themes, setThemes] = useState([]);
   const [currentTheme, setCurrentTheme] = useState(user.themePreference || 'light');
   const [showSettings, setShowSettings] = useState(false);
   const messagesEndRef = useRef(null);
   const socketRef = useRef(null);
+  const fileInputRef = useRef(null);
 
   useEffect(() => {
     loadSessions();
@@ -742,18 +744,40 @@ const ChatInterface = ({ user, token, onLogout }) => {
     }
   };
 
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  };
+
+  const handleImageChange = (e) => {
+    const file = e.target.files[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setSelectedImage(reader.result);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
   const sendMessage = async (e) => {
-    e.preventDefault();
-    if (!newMessage.trim() || !currentSession) return;
+    if (e) e.preventDefault();
+    if ((!newMessage.trim() && !selectedImage) || !currentSession) return;
 
     setLoading(true);
     const messageText = newMessage;
+    const imageData = selectedImage;
     setNewMessage('');
+    setSelectedImage(null);
+    if (fileInputRef.current) fileInputRef.current.value = null;
 
     try {
       await api.post('/api/chat/message', {
         sessionId: currentSession.id,
-        message: messageText
+        message: messageText,
+        image: imageData
       }, token);
     } catch (err) {
       console.error('Failed to send message:', err);
@@ -850,10 +874,14 @@ const ChatInterface = ({ user, token, onLogout }) => {
                 {messages.map((message) => (
                   <div
                     key={message.id}
-                    className={`message ${message.message_type === 'user' ? 'user-message' : 'bot-message'}`}
+                    className={`message ${message.message_type === 'bot' ? 'bot-message' : 'user-message'}`}
                   >
                     <div className="message-content">
-                      <div className="message-text">{message.message_text}</div>
+                      {message.message_text.startsWith('data:image') ? (
+                        <img src={message.message_text} alt="sent" className="message-image" />
+                      ) : (
+                        <div className="message-text">{message.message_text}</div>
+                      )}
                       <div className="message-time">
                         {formatTimestamp(message.created_at)}
                         {message.response_time_ms && (
@@ -870,18 +898,31 @@ const ChatInterface = ({ user, token, onLogout }) => {
               </div>
 
               <form className="message-input-form" onSubmit={sendMessage}>
+                {selectedImage && (
+                  <div className="image-preview">
+                    <img src={selectedImage} alt="preview" />
+                  </div>
+                )}
                 <div className="input-container">
-                  <input
-                    type="text"
+                  <textarea
                     value={newMessage}
                     onChange={(e) => setNewMessage(e.target.value)}
                     placeholder="Type your message..."
                     disabled={loading}
                     className="message-input"
+                    rows={2}
+                    onKeyDown={handleKeyDown}
+                  />
+                  <input
+                    type="file"
+                    accept="image/*"
+                    onChange={handleImageChange}
+                    disabled={loading}
+                    ref={fileInputRef}
                   />
                   <button
                     type="submit"
-                    disabled={loading || !newMessage.trim()}
+                    disabled={loading || (!newMessage.trim() && !selectedImage)}
                     className="send-button"
                   >
                     {loading ? 'Sending...' : 'Send'}


### PR DESCRIPTION
## Summary
- allow sending chat messages with optional image attachments
- use textarea with Shift+Enter for newline when composing messages
- extend chat message API to handle image content and skip webhook for images

## Testing
- `cd frontend && npm test -- --watchAll=false` *(fails: No tests found)*
- `cd ../backend && npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6896fcfae8508329a47a35b690224492