### PR TITLE
feat: enable updating customer branding

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -341,6 +341,8 @@ app.post('/api/auth/login', async (req, res) => {
                 email: user.email,
                 firstName: user.first_name,
                 lastName: user.last_name,
+                customerName: user.customer_name,
+                productLogo: user.product_logo,
                 themePreference: user.theme_preference,
                 emailVerified: user.email_verified
             }
@@ -440,11 +442,49 @@ app.get('/api/user/profile', authenticateToken, (req, res) => {
         email: req.user.email,
         firstName: req.user.first_name,
         lastName: req.user.last_name,
+        customerName: req.user.customer_name,
+        productLogo: req.user.product_logo,
         themePreference: req.user.theme_preference,
         emailVerified: req.user.email_verified,
         createdAt: req.user.created_at,
         lastLogin: req.user.last_login
     });
+});
+
+// Update user profile
+app.put('/api/user/profile', authenticateToken, async (req, res) => {
+    try {
+        const { customerName, productLogo } = req.body;
+        await pool.query(
+            `UPDATE users SET customer_name = $1, product_logo = $2, updated_at = CURRENT_TIMESTAMP WHERE id = $3`,
+            [customerName, productLogo, req.user.id]
+        );
+
+        const result = await pool.query(
+            `SELECT id, email, first_name, last_name, customer_name, product_logo, theme_preference, email_verified, created_at, last_login
+             FROM users WHERE id = $1`,
+            [req.user.id]
+        );
+
+        res.json({
+            message: 'Profile updated successfully',
+            user: {
+                id: result.rows[0].id,
+                email: result.rows[0].email,
+                firstName: result.rows[0].first_name,
+                lastName: result.rows[0].last_name,
+                customerName: result.rows[0].customer_name,
+                productLogo: result.rows[0].product_logo,
+                themePreference: result.rows[0].theme_preference,
+                emailVerified: result.rows[0].email_verified,
+                createdAt: result.rows[0].created_at,
+                lastLogin: result.rows[0].last_login
+            }
+        });
+    } catch (error) {
+        logger.error('Profile update error:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
 });
 
 // Update verify-email endpoint to respect config.json

--- a/database_schema.sql
+++ b/database_schema.sql
@@ -7,6 +7,8 @@ CREATE TABLE users (
     password_hash VARCHAR(255) NOT NULL,
     first_name VARCHAR(100) NOT NULL,
     last_name VARCHAR(100) NOT NULL,
+    customer_name VARCHAR(255),
+    product_logo VARCHAR(500),
     theme_preference VARCHAR(50) DEFAULT 'light',
     is_active BOOLEAN DEFAULT true,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -622,14 +622,59 @@ const ThemeSelector = ({ currentTheme, themes, onThemeChange, token }) => {
   );
 };
 
+const ProfileSettings = ({ user, onUpdate, token }) => {
+  const [customerName, setCustomerName] = useState(user?.customerName || '');
+  const [productLogo, setProductLogo] = useState(user?.productLogo || '');
+  const [loading, setLoading] = useState(false);
+
+  const handleSave = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const response = await api.put('/api/user/profile', { customerName, productLogo }, token);
+      const updatedUser = response.user;
+      localStorage.setItem('user', JSON.stringify(updatedUser));
+      onUpdate(updatedUser);
+    } catch (err) {
+      console.error('Failed to update profile:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="profile-settings">
+      <h4>Profile</h4>
+      <form onSubmit={handleSave}>
+        <label>Customer Name</label>
+        <input
+          type="text"
+          value={customerName}
+          onChange={(e) => setCustomerName(e.target.value)}
+        />
+        <label>Product Logo URL</label>
+        <input
+          type="text"
+          value={productLogo}
+          onChange={(e) => setProductLogo(e.target.value)}
+        />
+        <button type="submit" disabled={loading}>
+          {loading ? 'Saving...' : 'Save'}
+        </button>
+      </form>
+    </div>
+  );
+};
+
 // Settings Menu Component
-const SettingsMenu = ({ visible, onClose, currentTheme, themes, onThemeChange, token }) => {
+const SettingsMenu = ({ visible, onClose, currentTheme, themes, onThemeChange, token, user, onUserUpdate }) => {
   if (!visible) return null;
 
   return (
     <div className="settings-menu">
       <div className="settings-content">
         <h2>Settings</h2>
+        <ProfileSettings user={user} onUpdate={onUserUpdate} token={token} />
         <ThemeSelector
           currentTheme={currentTheme}
           themes={themes}
@@ -645,7 +690,7 @@ const SettingsMenu = ({ visible, onClose, currentTheme, themes, onThemeChange, t
 };
 
 // Chat Interface Component
-const ChatInterface = ({ user, token, onLogout }) => {
+const ChatInterface = ({ user, setUser, token, onLogout }) => {
   const [sessions, setSessions] = useState([]);
   const [currentSession, setCurrentSession] = useState(null);
   const [messages, setMessages] = useState([]);
@@ -955,6 +1000,8 @@ const ChatInterface = ({ user, token, onLogout }) => {
       themes={themes}
       onThemeChange={handleThemeChange}
       token={token}
+      user={user}
+      onUserUpdate={setUser}
     />
     </>
   );
@@ -1015,7 +1062,7 @@ const App = () => {
   }
 
   if (user && token) {
-    return <ChatInterface user={user} token={token} onLogout={handleLogout} />;
+    return <ChatInterface user={user} setUser={setUser} token={token} onLogout={handleLogout} />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- allow storing customerName and productLogo for users
- add profile update API and return branding fields on login
- support editing customer name and logo from settings UI

## Testing
- `npm test` *(backend: no tests found)*
- `npm test -- --watchAll=false` *(frontend: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6897516a333883298f9149959be006d0